### PR TITLE
Add a dev backend proxy to handle CORS in local development

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,11 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "PORT=8080 react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "npm run lint && react-scripts test",
     "lint": "eslint \"**/*.tsx\"",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "dev:backend-proxy": "node src/dev-backend-proxy.js"
   },
   "dependencies": {
     "@material-ui/core": "4.10.0",
@@ -33,6 +34,7 @@
     "@types/react-router-dom": "5.1.5",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
+    "http-proxy": "1.18.1",
     "node-sass": "4.14.1",
     "react-scripts": "3.4.1",
     "typescript": "3.7.2"

--- a/frontend/src/app/services/apiClientService.tsx
+++ b/frontend/src/app/services/apiClientService.tsx
@@ -13,7 +13,10 @@ function fetchJSON<T>(url: string, init?: IRequestInit | undefined): Promise<T> 
     },
   }).then((res) => {
     if (res.ok) {
-      return res.json();
+      // NOTE: Some endpoints return empty result while still reporting
+      // Content-Type: application/json, so just revert to null
+      // value if the JSON parsing fails
+      return res.json().catch(() => null);
     } else {
       throw Error(`${res.status} ${url}`);
     }

--- a/frontend/src/app/services/services.tsx
+++ b/frontend/src/app/services/services.tsx
@@ -40,7 +40,9 @@ export function createServices() {
 
   // NOTE: Make sure you populate all services here
   services.historyService = createHistoryService();
-  services.apiClientService = createAPIClientService("http://localhost:5000");
+  services.apiClientService = createAPIClientService(
+    process.env.NODE_ENV === "production" ? "" : "http://localhost:5000"
+  );
   services.storeService = configureStore({
     reducer: rootStore,
     middleware: [

--- a/frontend/src/dev-backend-proxy.js
+++ b/frontend/src/dev-backend-proxy.js
@@ -1,0 +1,38 @@
+/*
+  Small proxy server to handle CORS issues in development
+*/
+const http = require("http");
+const httpProxy = require("http-proxy");
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "*",
+  "Access-Control-Allow-Methods": "*",
+};
+
+var proxy = httpProxy.createProxyServer({
+  target: "http://localhost:8000",
+  headers: corsHeaders,
+});
+
+proxy.on("proxyRes", (proxyRes, req) => {
+  console.log(`< ${proxyRes.statusCode} ${req.method} ${req.url}`);
+});
+
+const server = http.createServer(function (req, res) {
+  console.log(`> ${req.method} ${req.url}`);
+
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, corsHeaders);
+    return res.end();
+  }
+
+  proxy.web(req, res);
+});
+
+server.listen(5000, () => {
+  const addr = server.address();
+  console.log(
+    `Proxy listening at ${typeof addr === "string" ? addr : `${addr.address}:${addr.port}`}`
+  );
+});


### PR DESCRIPTION
To use the development backend with sane CORS-abilities, you need to start the local backend and then start the proxy that this PR adds.

Run the local backend in one terminal, this will serve at `localhost:8000`:

```sh
cd <project-root>
# If you haven't yet built the backend or it needs to be updated:
# docker-compose build
docker-compose up
```

Now start the proxy in `frontend` directory, this will serve at `localhost:5000`, passing all requests to `localhost:8000` except pre-flight requests and setting very permissive CORS-headers for all requests.

```sh
cd <project-root>/frontend
npm start dev:backend-proxy
```

Then when you start the frontend project with `npm start`, it will call the API at the proxy address `localhost:5000`. Bundled frontend however will however access the API at _self_ URL just like in production.