### PR TITLE
Add a default shift for every site

### DIFF
--- a/admins.yaml
+++ b/admins.yaml
@@ -1,1 +1,2 @@
 - office-tracker@futurice.com
+- jan.van.brugge@futurice.com

--- a/shifts.yaml
+++ b/shifts.yaml
@@ -1,0 +1,9 @@
+- days: [1, 2, 3, 4, 5, 6, 7]
+  name: default
+  site: Munich
+- days: [1, 2, 3, 4, 5, 6, 7]
+  name: default
+  site: Berlin
+- days: [1, 2, 3, 4, 5, 6, 7]
+  name: default
+  site: Stuttgart


### PR DESCRIPTION
I've already deployed this version on production and staging, and imported the list of all users into both systems