### PR TITLE
fix mui navbar default scrolling behavior

### DIFF
--- a/frontend/src/app/ui/siteLayout/NavigationBar.tsx
+++ b/frontend/src/app/ui/siteLayout/NavigationBar.tsx
@@ -99,7 +99,7 @@ const AvatarContainer = styled("div")({
 });
 
 export const NavigationBar: React.FC<INavigationBar> = ({ user }) => (
-  <StyledAppBar position="static" className="NavigationBar">
+  <StyledAppBar position="fixed" className="NavigationBar">
     <StyledToolbar>
       <AppTitleLink to={RoutePaths.Home} aria-label="Home">
         <IconLogoLight height="32" width="28" /> <AppTitle>futuLog</AppTitle>


### PR DESCRIPTION
Materials UI navbar's default behavior is such that navbar (app bar) hides on scroll down to leave more space for reading. In FutuLog's UI this led to a bug when scrolling. The change makes the navbar fully sticky.